### PR TITLE
Add missing fotorama.png to bower.json main files

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -8,7 +8,9 @@
   "description": "A simple, stunning, powerful jQuery gallery.",
   "main": [
     "fotorama.css",
-    "fotorama.js"
+    "fotorama.js",
+    "fotorama.png",
+    "fotorama@2x.png"
   ],
   "keywords": [
     "gallery",


### PR DESCRIPTION
These fotorama.png is needed by the plugin and should be included in the main files.
Other plugins use the main files to determine which files to copy.